### PR TITLE
dockerimage: add qa debug image

### DIFF
--- a/pipelines/pre-release-docker.groovy
+++ b/pipelines/pre-release-docker.groovy
@@ -90,15 +90,15 @@ def release_one(repo,failpoint) {
             parameters: paramsBuild
 
     def dockerfile = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/linux-amd64/${repo}"
-    def image = "hub-new.pingcap.net/qa/${repo}:${IMAGE_TAG},pingcap/${repo}:${IMAGE_TAG}"
+    def image = "hub.pingcap.net/qa/${repo}:${IMAGE_TAG},pingcap/${repo}:${IMAGE_TAG}"
     if (repo == "tics") {
-        image = image + ",hub-new.pingcap.net/qa/tiflash:${IMAGE_TAG},pingcap/tiflash:${IMAGE_TAG}"
+        image = image + ",hub.pingcap.net/qa/tiflash:${IMAGE_TAG},pingcap/tiflash:${IMAGE_TAG}"
     }
     if (repo == "monitoring") {
-        image = "hub-new.pingcap.net/qa/tidb-monitor-initializer:${IMAGE_TAG},pingcap/tidb-monitor-initializer:${IMAGE_TAG}"
+        image = "hub.pingcap.net/qa/tidb-monitor-initializer:${IMAGE_TAG},pingcap/tidb-monitor-initializer:${IMAGE_TAG}"
     }
     if (failpoint) {
-        image = "hub-new.pingcap.net/qa/${repo}:${IMAGE_TAG}-failpoint"
+        image = "hub.pingcap.net/qa/${repo}:${IMAGE_TAG}-failpoint"
     }
     def paramsDocker = [
         string(name: "ARCH", value: "amd64"),
@@ -117,9 +117,9 @@ def release_one(repo,failpoint) {
 
     if (NEED_DEBUG_IMAGE) {
         def dockerfileForDebug = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/debug-image/${repo}"
-        def imageForDebug = "hub-new.pingcap.net/qa/${repo}:${IMAGE_TAG}-debug"
+        def imageForDebug = "hub.pingcap.net/qa/${repo}:${IMAGE_TAG}-debug"
         if (failpoint) {
-            imageForDebug = "hub-new.pingcap.net/qa/${repo}:${IMAGE_TAG}-failpoint-debug"
+            imageForDebug = "hub.pingcap.net/qa/${repo}:${IMAGE_TAG}-failpoint-debug"
         }
         def paramsDockerForDebug = [
             string(name: "ARCH", value: "amd64"),
@@ -138,10 +138,10 @@ def release_one(repo,failpoint) {
         }
     }
     
-    
+
     if (repo == "br") {
         def dockerfileLightning = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/linux-amd64/lightning"
-        def imageLightling = "hub-new.pingcap.net/qa/tidb-lightning:${IMAGE_TAG},pingcap/tidb-lightning:${IMAGE_TAG}"
+        def imageLightling = "hub.pingcap.net/qa/tidb-lightning:${IMAGE_TAG},pingcap/tidb-lightning:${IMAGE_TAG}"
         def paramsDockerLightning = [
             string(name: "ARCH", value: "amd64"),
             string(name: "OS", value: "linux"),
@@ -159,7 +159,7 @@ def release_one(repo,failpoint) {
 
         if (NEED_DEBUG_IMAGE) {
             def dockerfileLightningForDebug = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/debug-image/lightning"
-            def imageLightlingForDebug = "hub-new.pingcap.net/qa/tidb-lightning:${IMAGE_TAG}-debug"
+            def imageLightlingForDebug = "hub.pingcap.net/qa/tidb-lightning:${IMAGE_TAG}-debug"
             def paramsDockerLightningForDebug = [
                 string(name: "ARCH", value: "amd64"),
                 string(name: "OS", value: "linux"),

--- a/pipelines/release-all-images-by-branch.groovy
+++ b/pipelines/release-all-images-by-branch.groovy
@@ -100,11 +100,8 @@ def release_one(repo,failpoint) {
 
     def dockerfileForDebug = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/debug-image/${repo}"
     def imageForDebug = "hub.pingcap.net/qa/${repo}:${GIT_BRANCH}-debug"
-    if (repo == "tics") {
-        imageForDebug = imageForDebug + ",hub.pingcap.net/qa/tiflash:${GIT_BRANCH}-debug"
-    }
     if (failpoint) {
-        imageForDebug = "${imageForDebug}-failpoint"
+        imageForDebug = "hub.pingcap.net/qa/${repo}:${GIT_BRANCH}-failpoint-debug"
     }
     def paramsDockerForDebug = [
         string(name: "ARCH", value: "amd64"),
@@ -116,9 +113,11 @@ def release_one(repo,failpoint) {
         string(name: "DOCKERFILE", value: dockerfileForDebug),
         string(name: "RELEASE_DOCKER_IMAGES", value: imageForDebug),
     ]
-    build job: "docker-common",
+    if (repo != "tics") {
+        build job: "docker-common",
             wait: true,
             parameters: paramsDockerForDebug
+    }
 
 
     if (repo == "br") {

--- a/pipelines/release-all-images-by-branch.groovy
+++ b/pipelines/release-all-images-by-branch.groovy
@@ -76,9 +76,9 @@ def release_one(repo,failpoint) {
             parameters: paramsBuild
 
     def dockerfile = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/linux-amd64/${repo}"
-    def image = "hub-new.pingcap.net/qa/${repo}:${GIT_BRANCH}"
+    def image = "hub.pingcap.net/qa/${repo}:${GIT_BRANCH}"
     if (repo == "tics") {
-        image = image + ",hub-new.pingcap.net/qa/tiflash:${GIT_BRANCH}"
+        image = image + ",hub.pingcap.net/qa/tiflash:${GIT_BRANCH}"
     }
     if (failpoint) {
         image = "${image}-failpoint"
@@ -99,9 +99,9 @@ def release_one(repo,failpoint) {
 
 
     def dockerfileForDebug = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/debug-image/${repo}"
-    def imageForDebug = "hub-new.pingcap.net/qa/${repo}:${GIT_BRANCH}-debug"
+    def imageForDebug = "hub.pingcap.net/qa/${repo}:${GIT_BRANCH}-debug"
     if (repo == "tics") {
-        imageForDebug = imageForDebug + ",hub-new.pingcap.net/qa/tiflash:${GIT_BRANCH}-debug"
+        imageForDebug = imageForDebug + ",hub.pingcap.net/qa/tiflash:${GIT_BRANCH}-debug"
     }
     if (failpoint) {
         imageForDebug = "${imageForDebug}-failpoint"
@@ -123,7 +123,7 @@ def release_one(repo,failpoint) {
 
     if (repo == "br") {
         def dockerfileLightning = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/linux-amd64/lightning"
-        def imageLightling = "hub-new.pingcap.net/qa/tidb-lightning:${GIT_BRANCH}"
+        def imageLightling = "hub.pingcap.net/qa/tidb-lightning:${GIT_BRANCH}"
         def paramsDockerLightning = [
             string(name: "ARCH", value: "amd64"),
             string(name: "OS", value: "linux"),
@@ -140,7 +140,7 @@ def release_one(repo,failpoint) {
         }
 
         def dockerfileLightningForDebug = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/debug-image/lightning"
-        def imageLightningForDebug = "hub-new.pingcap.net/qa/tidb-lightning:${GIT_BRANCH}-debug"
+        def imageLightningForDebug = "hub.pingcap.net/qa/tidb-lightning:${GIT_BRANCH}-debug"
         def paramsDockerLightningForDebug = [
             string(name: "ARCH", value: "amd64"),
             string(name: "OS", value: "linux"),

--- a/pipelines/release-all-images-by-branch.groovy
+++ b/pipelines/release-all-images-by-branch.groovy
@@ -97,6 +97,30 @@ def release_one(repo,failpoint) {
             wait: true,
             parameters: paramsDocker
 
+
+    def dockerfileForDebug = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/debug-image/${repo}"
+    def imageForDebug = "hub-new.pingcap.net/qa/${repo}:${GIT_BRANCH}-debug"
+    if (repo == "tics") {
+        imageForDebug = imageForDebug + ",hub-new.pingcap.net/qa/tiflash:${GIT_BRANCH}-debug"
+    }
+    if (failpoint) {
+        imageForDebug = "${imageForDebug}-failpoint"
+    }
+    def paramsDockerForDebug = [
+        string(name: "ARCH", value: "amd64"),
+        string(name: "OS", value: "linux"),
+        string(name: "INPUT_BINARYS", value: binary),
+        string(name: "REPO", value: repo),
+        string(name: "PRODUCT", value: repo),
+        string(name: "RELEASE_TAG", value: RELEASE_TAG),
+        string(name: "DOCKERFILE", value: dockerfileForDebug),
+        string(name: "RELEASE_DOCKER_IMAGES", value: imageForDebug),
+    ]
+    build job: "docker-common",
+            wait: true,
+            parameters: paramsDockerForDebug
+
+
     if (repo == "br") {
         def dockerfileLightning = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/linux-amd64/lightning"
         def imageLightling = "hub-new.pingcap.net/qa/tidb-lightning:${GIT_BRANCH}"
@@ -114,6 +138,22 @@ def release_one(repo,failpoint) {
                 wait: true,
                 parameters: paramsDockerLightning
         }
+
+        def dockerfileLightningForDebug = "https://raw.githubusercontent.com/PingCAP-QE/ci/main/jenkins/Dockerfile/release/debug-image/lightning"
+        def imageLightningForDebug = "hub-new.pingcap.net/qa/tidb-lightning:${GIT_BRANCH}-debug"
+        def paramsDockerLightningForDebug = [
+            string(name: "ARCH", value: "amd64"),
+            string(name: "OS", value: "linux"),
+            string(name: "INPUT_BINARYS", value: binary),
+            string(name: "REPO", value: "lightning"),
+            string(name: "PRODUCT", value: "lightning"),
+            string(name: "RELEASE_TAG", value: RELEASE_TAG),
+            string(name: "DOCKERFILE", value: dockerfileLightningForDebug),
+            string(name: "RELEASE_DOCKER_IMAGES", value: imageLightningForDebug),
+        ]
+        build job: "docker-common",
+                wait: true,
+                parameters: paramsDockerLightningForDebug
 }
 
 stage ("release") {


### PR DESCRIPTION
* build some docker image that used to debug 
* add param NEED_DEBUG_IMAGE to switch on build debug image, default is true
* modify harbor from `hub-new` to `hub`
* only push debug image to internal harbor, not dockerhub registry