### PR TITLE
actual repo of ticdc is tiflow now

### DIFF
--- a/pipelines/pre-release-docker.groovy
+++ b/pipelines/pre-release-docker.groovy
@@ -53,6 +53,9 @@ def release_one(repo,arch,failpoint) {
     if (repo == "dumpling" && RELEASE_TAG >= "v5.3.0") {
         actualRepo = "tidb"
     }
+    if (repo == "ticdc") {
+        actualRepo = "tiflow"
+    }
     def sha1 = get_sha(actualRepo,RELEASE_BRANCH)
     if (TIKV_BUMPVERION_HASH.length() > 1 && repo == "tikv") {
         sha1 = TIKV_BUMPVERION_HASH

--- a/pipelines/release-all-images-by-branch.groovy
+++ b/pipelines/release-all-images-by-branch.groovy
@@ -51,6 +51,9 @@ def release_one(repo,failpoint) {
     if (repo == "br" && GIT_BRANCH.startsWith("release-") && GIT_BRANCH >= "release-5.2") {
         actualRepo = "tidb"
     }
+    if (repo == "ticdc") {
+        actualRepo = "tiflow"
+    }
     def sha1 =  get_sha(actualRepo)
     def binary = "builds/pingcap/${repo}/test/${GIT_BRANCH}/${sha1}/linux-amd64/${repo}.tar.gz"
     if (failpoint) {


### PR DESCRIPTION
Part of step-4 in https://github.com/pingcap/ticdc/issues/3749

The actual repo of `ticdc` is `tiflow` now.