### PR TITLE
add clean up when start release

### DIFF
--- a/atom-jobs/docker-common.groovy
+++ b/atom-jobs/docker-common.groovy
@@ -60,10 +60,6 @@ if (params.PRODUCT.length() <= 1) {
     PRODUCT = REPO
 }
 
-def cleanup() {
-    sh "rm -rf ./"
-}
-
 // download binarys
 binarys = params.INPUT_BINARYS.split(",")
 def download() {
@@ -191,7 +187,7 @@ def release_images() {
 }
 
 def release() {
-    cleanup()
+    deleteDir()
     download()
     build_image()
     release_images()

--- a/atom-jobs/docker-common.groovy
+++ b/atom-jobs/docker-common.groovy
@@ -60,6 +60,10 @@ if (params.PRODUCT.length() <= 1) {
     PRODUCT = REPO
 }
 
+def cleanup() {
+    sh "rm -rf ./"
+}
+
 // download binarys
 binarys = params.INPUT_BINARYS.split(",")
 def download() {
@@ -187,6 +191,7 @@ def release_images() {
 }
 
 def release() {
+    cleanup()
     download()
     build_image()
     release_images()


### PR DESCRIPTION
some times there are dirty when init
```
[2022-02-11T12:42:28.189Z] + cp /usr/local/go/lib/time/zoneinfo.zip ./

[2022-02-11T12:42:28.189Z] + cp bin/arbiter bin/binlogctl bin/br bin/ddltest bin/drainer bin/dumpling bin/importer bin/pd-analysis bin/pd-ctl bin/pd-heartbeat-bench bin/pd-recover bin/pd-server bin/pd-tso-bench bin/pump bin/reparo bin/tidb-lightning bin/tidb-lightning-ctl bin/tidb-server bin/tidb-server-check bin/tidb-server-coverage bin/tidb-server-failpoint bin/tidb-server-race ./

[2022-02-11T12:42:28.189Z] cp: cannot overwrite directory ‘./br’ with non-directory

[2022-02-11T12:42:28.539Z] cp: cannot overwrite directory ‘./dumpling’ with non-directory

script returned exit code 1


```