### PR TITLE
fix binary has same name with dir

### DIFF
--- a/atom-jobs/docker-common.groovy
+++ b/atom-jobs/docker-common.groovy
@@ -129,8 +129,11 @@ def build_image() {
         sh buildImgagesh[PRODUCT]
     } else { // 如果没定义，使用默认构建脚本
         sh """
+        rm -rf tmp-docker-build
+        mkdir -p tmp-docker-build
+        cd tmp-docker-build
         cp /usr/local/go/lib/time/zoneinfo.zip ./
-        cp bin/* ./
+        cp ../bin/* ./
         curl -o Dockerfile ${DOCKERFILE}
         docker build  -t ${imagePlaceHolder} .
         """


### PR DESCRIPTION
some image build failed because binary has the same name with the dir

like tidb / br / dumpling