### PR TITLE
feat: tidb-tools v5.3.3 use go1.18.5 to build

### DIFF
--- a/atom-jobs/build-common.groovy
+++ b/atom-jobs/build-common.groovy
@@ -185,7 +185,7 @@ if (REPO != "tidb-tools") {
 // workaround for v 5.3.3 tidb-tools,
 // need use go1.18.5 to build tidb-tools
 // revert this after  v5.3.3 ga
-if (REPO == "tidb-tools" && RELEASE_TAG == "v5.3.3" GIT_HASH == "cf6b7a8ae4b5849a6155634352b3712059defb48") {
+if (REPO == "tidb-tools" && RELEASE_TAG == "v5.3.3" && GIT_HASH == "cf6b7a8ae4b5849a6155634352b3712059defb48") {
         goBuildPod = "build_go1185"
         GO_BIN_PATH = "/usr/local/go1.18.5/bin"
         println "tidb-tools v5.3.3 use go1.18.5 to build"

--- a/atom-jobs/build-common.groovy
+++ b/atom-jobs/build-common.groovy
@@ -182,6 +182,14 @@ if (REPO != "tidb-tools") {
         GO_BIN_PATH = "/usr/local/go/bin"
     }
 }
+// workaround for v 5.3.3 tidb-tools,
+// need use go1.18.5 to build tidb-tools
+// revert this after  v5.3.3 ga
+if (REPO == "tidb-tools" && RELEASE_TAG == "v5.3.3" GIT_HASH == "cf6b7a8ae4b5849a6155634352b3712059defb48") {
+        goBuildPod = "build_go1185"
+        GO_BIN_PATH = "/usr/local/go1.18.5/bin"
+        println "tidb-tools v5.3.3 use go1.18.5 to build"
+}
 
 // choose which node to use.
 def nodeLabel = goBuildPod


### PR DESCRIPTION
* tidb-tools v5.3.3 use the same hash with v5.2.2, need go1.18 to build