### PR TITLE
feat: upgrade go version to 1.19.3

### DIFF
--- a/atom-jobs/build-common.groovy
+++ b/atom-jobs/build-common.groovy
@@ -113,7 +113,7 @@ if (params.FAILPOINT) {
 
 // check if binary already has been built. 
 def ifFileCacheExists() {
-    return false
+    // return false // to re-run force build
     if (params.FORCE_REBUILD){
         return false
     } 

--- a/atom-jobs/build-common.groovy
+++ b/atom-jobs/build-common.groovy
@@ -113,6 +113,7 @@ if (params.FAILPOINT) {
 
 // check if binary already has been built. 
 def ifFileCacheExists() {
+    return false
     if (params.FORCE_REBUILD){
         return false
     } 
@@ -153,6 +154,13 @@ def String needUpgradeGoVersion(String tag,String branch) {
     }
     if (branch.startsWith("release-") && branch >= "release-5.1" && branch < "release-6.0"){
         return "go1.16"
+    }
+    // special for release-6.1 later versions
+    if (branch == "release-6.1"){
+        return "go1.19"
+    }
+    if (branch.startsWith("release-") && branch >= "release-6.0" && branch < "release-6.3"){
+        return "go1.18"
     }
     if (branch.startsWith("hz-poc") || branch.startsWith("arm-dup") ) {
         return "go1.16"

--- a/atom-jobs/build-common.groovy
+++ b/atom-jobs/build-common.groovy
@@ -141,7 +141,11 @@ def String needUpgradeGoVersion(String tag,String branch) {
     if (tag.startsWith("v") && tag > "v5.1" && tag < "v6.0") {
         return "go1.16"
     }
-    if (tag.startsWith("v") && tag >= "v6.1" && tag < "v6.1.3") {
+    // special for v6.1 larger than patch 3
+    if (tag.startsWith("v6.1") && tag >= "v6.1.3") {
+        return "go1.19"
+    }
+    if (tag.startsWith("v") && tag >= "v6.0" && tag < "v6.3") {
         return "go1.18"
     }
     if (branch.startsWith("release-") && branch < "release-5.1"){

--- a/atom-jobs/build-common.groovy
+++ b/atom-jobs/build-common.groovy
@@ -210,7 +210,7 @@ if (params.PRODUCT == "tics") {
     containerLabel = "tiflash"
 } 
 if (params.ARCH == "arm64" && params.OS == "linux" && !useArmPod) {
-    binPath = "/usr/local/node/bin:/root/.cargo/bin:/usr/lib64/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:${GO_BIN_PATH}"
+    binPath = "${GO_BIN_PATH}:/usr/local/node/bin:/root/.cargo/bin:/usr/lib64/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin"
     nodeLabel = "arm"
     containerLabel = ""
     if (params.PRODUCT == "tics"){
@@ -219,13 +219,13 @@ if (params.ARCH == "arm64" && params.OS == "linux" && !useArmPod) {
     }
 }
 if (params.OS == "darwin" && params.ARCH == "amd64") {
-    binPath = "/opt/homebrew/bin:/opt/homebrew/sbin:/Users/pingcap/.cargo/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/pingcap/.cargo/bin:${GO_BIN_PATH}:/usr/local/opt/binutils/bin/"
+    binPath = "${GO_BIN_PATH}:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/pingcap/.cargo/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/pingcap/.cargo/bin:/usr/local/opt/binutils/bin/"
     nodeLabel = "mac"
     containerLabel = ""
 }
 
 if (params.OS == "darwin" && params.ARCH == "arm64") {
-    binPath = "/opt/homebrew/bin:/opt/homebrew/sbin:/Users/pingcap/.cargo/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/pingcap/.cargo/bin:${GO_BIN_PATH}:/usr/local/opt/binutils/bin/"
+    binPath = "${GO_BIN_PATH}:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/pingcap/.cargo/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/pingcap/.cargo/bin:/usr/local/opt/binutils/bin/"
     nodeLabel = "mac-arm"
     containerLabel = ""
     if (params.PRODUCT == "tics"){

--- a/atom-jobs/build-common.groovy
+++ b/atom-jobs/build-common.groovy
@@ -163,7 +163,7 @@ def String needUpgradeGoVersion(String tag,String branch) {
 }
 
 def goBuildPod = "build_go1190"
-def GO_BIN_PATH = "/usr/local/go1.19.2/bin"
+def GO_BIN_PATH = "/usr/local/go1.19.3/bin"
 goVersion = needUpgradeGoVersion(params.RELEASE_TAG,params.TARGET_BRANCH)
 // tidb-tools only use branch master and use newest go version
 if (REPO != "tidb-tools") {

--- a/atom-jobs/build-common.groovy
+++ b/atom-jobs/build-common.groovy
@@ -141,7 +141,7 @@ def String needUpgradeGoVersion(String tag,String branch) {
     if (tag.startsWith("v") && tag > "v5.1" && tag < "v6.0") {
         return "go1.16"
     }
-    if (tag.startsWith("v") && tag >= "v6.0" && tag < "v6.3") {
+    if (tag.startsWith("v") && tag >= "v6.1" && tag < "v6.1.3") {
         return "go1.18"
     }
     if (branch.startsWith("release-") && branch < "release-5.1"){
@@ -149,9 +149,6 @@ def String needUpgradeGoVersion(String tag,String branch) {
     }
     if (branch.startsWith("release-") && branch >= "release-5.1" && branch < "release-6.0"){
         return "go1.16"
-    }
-    if (branch.startsWith("release-") && branch >= "release-6.0" && branch < "release-6.3"){
-        return "go1.18"
     }
     if (branch.startsWith("hz-poc") || branch.startsWith("arm-dup") ) {
         return "go1.16"

--- a/atom-jobs/docker-common.groovy
+++ b/atom-jobs/docker-common.groovy
@@ -87,7 +87,7 @@ cd monitoring/
 mv Dockerfile Dockerfile.bak || true
 curl -C - --retry 5 --retry-delay 6 --retry-max-time 60 -o Dockerfile ${DOCKERFILE}
 cat Dockerfile
-docker build  -t ${imagePlaceHolder} .
+docker build --pull  -t ${imagePlaceHolder} .
 """
 
 buildImgagesh["tics"] = """
@@ -96,10 +96,10 @@ curl -C - --retry 5 --retry-delay 6 --retry-max-time 60 -o Dockerfile ${DOCKERFI
 cat Dockerfile
 if [[ "${RELEASE_TAG}" == "" ]]; then
     # No release tag, the image may be used in testings
-    docker build -t ${imagePlaceHolder} . --build-arg INSTALL_MYSQL=1
+    docker build --pull -t ${imagePlaceHolder} . --build-arg INSTALL_MYSQL=1
 else
     # Release tag provided, do not install test utils
-    docker build -t ${imagePlaceHolder} . --build-arg INSTALL_MYSQL=0
+    docker build --pull -t ${imagePlaceHolder} . --build-arg INSTALL_MYSQL=0
 fi
 """
 
@@ -109,21 +109,21 @@ curl -C - --retry 5 --retry-delay 6 --retry-max-time 60 -o Dockerfile ${DOCKERFI
 cat Dockerfile
 if [[ "${RELEASE_TAG}" == "" ]]; then
     # No release tag, the image may be used in testings
-    docker build -t ${imagePlaceHolder} . --build-arg INSTALL_MYSQL=1
+    docker build --pull -t ${imagePlaceHolder} . --build-arg INSTALL_MYSQL=1
 else
     # Release tag provided, do not install test utils
-    docker build -t ${imagePlaceHolder} . --build-arg INSTALL_MYSQL=0
+    docker build --pull -t ${imagePlaceHolder} . --build-arg INSTALL_MYSQL=0
 fi
 """
 
 
 buildImgagesh["monitoring"] = """
-docker build -t ${imagePlaceHolder} .
+docker build --pull -t ${imagePlaceHolder} .
 """
 
 buildImgagesh["tiem"] = """
 cp /usr/local/go/lib/time/zoneinfo.zip ./
-docker build  -t ${imagePlaceHolder} .
+docker build --pull  -t ${imagePlaceHolder} .
 """
 
 buildImgagesh["tidb"] = """
@@ -141,7 +141,7 @@ fi
 mv Dockerfile Dockerfile.bak || true
 curl -C - --retry 5 --retry-delay 6 --retry-max-time 60 -o Dockerfile ${DOCKERFILE}
 cat Dockerfile
-docker build  -t ${imagePlaceHolder} .
+docker build --pull  -t ${imagePlaceHolder} .
 """
 
 
@@ -160,7 +160,7 @@ def build_image() {
         mv Dockerfile Dockerfile.bak || true
         curl -C - --retry 5 --retry-delay 6 --retry-max-time 60 -o Dockerfile ${DOCKERFILE}
         cat Dockerfile
-        docker build  -t ${imagePlaceHolder} .
+        docker build --pull  -t ${imagePlaceHolder} .
         """
     }
 }


### PR DESCRIPTION
This PR
- upgrade go version to 1.19.3
- fix native machine will always use latest go because go in path