### PR TITLE
fix(build-common): fix curl not found when download src-code cache

### DIFF
--- a/atom-jobs/build-common.groovy
+++ b/atom-jobs/build-common.groovy
@@ -869,10 +869,14 @@ def packageBinary() {
 }
 
 def release(product, label) {
-    checkoutStartTimeInMillis = System.currentTimeMillis()
-    checkoutCode()
-    checkoutFinishTimeInMillis = System.currentTimeMillis()
-
+    if (label != '') {
+        container(label) {
+            checkoutStartTimeInMillis = System.currentTimeMillis()
+            checkoutCode()
+            checkoutFinishTimeInMillis = System.currentTimeMillis()
+        }
+    }
+    
     if (PRODUCT == 'tics') {
         if (fileExists('release-centos7-llvm/scripts/build-release.sh') && params.OS != "darwin") {
             def image_tag_suffix = ""
@@ -953,7 +957,9 @@ def run_with_arm_go_pod(Closure body) {
     ) {
         node(label) {
             println "debug command:\nkubectl -n ${namespace} exec -ti ${NODE_NAME} bash"
-            body()
+            container("golang") {
+                body()
+            }
         }
     }
 }


### PR DESCRIPTION
### Why
k8s pod scheduled by jenkins k8s plugin use jnlp as the default container. If no container lable is specified, downloading the code cache will result in a curl not found error. 

### How
Explicitly specify the container label to be used. 

### tested
1. https://cd.pingcap.net/blue/organizations/jenkins/build-common/detail/build-common/178697/pipeline
2. https://cd.pingcap.net/blue/organizations/jenkins/build-common/detail/build-common/178698/pipeline