### PR TITLE
ci: replace deprecated PingCAP domains

### DIFF
--- a/atom-jobs/archive-to-s3.groovy
+++ b/atom-jobs/archive-to-s3.groovy
@@ -22,8 +22,8 @@ node("delivery") {
             sh """
     export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-bundle.crt
     upload.py ${target}  ${target}
-    aws s3 cp ${target} s3://download.pingcap.org/${target} --acl public-read
-    echo "upload ${target} successed!\n[########download path#########]: https://download.pingcap.org/${target}"
+    aws s3 cp ${target} s3://download.pingcap.com/${target} --acl public-read
+    echo "upload ${target} successed!\n[########download path#########]: https://download.pingcap.com/${target}"
     """
         }
     }

--- a/atom-jobs/build-common.groovy
+++ b/atom-jobs/build-common.groovy
@@ -580,7 +580,7 @@ if [[ -d "dm/dm/dm-ansible" ]]; then
 fi;
 
 if [[ ${ARCH} == "amd64" ]]; then
-    curl http://download.pingcap.org/mydumper-latest-linux-amd64.tar.gz | tar xz
+    curl http://download.pingcap.com/mydumper-latest-linux-amd64.tar.gz | tar xz
     mv mydumper-latest-linux-amd64/bin/mydumper bin/ && rm -rf mydumper-latest-linux-amd64
 fi;
 cp bin/* ${TARGET}/bin/

--- a/atom-jobs/build-common.groovy
+++ b/atom-jobs/build-common.groovy
@@ -580,7 +580,7 @@ if [[ -d "dm/dm/dm-ansible" ]]; then
 fi;
 
 if [[ ${ARCH} == "amd64" ]]; then
-    curl http://download.pingcap.com/mydumper-latest-linux-amd64.tar.gz | tar xz
+    curl https://download.pingcap.com/mydumper-latest-linux-amd64.tar.gz | tar xz
     mv mydumper-latest-linux-amd64/bin/mydumper bin/ && rm -rf mydumper-latest-linux-amd64
 fi;
 cp bin/* ${TARGET}/bin/


### PR DESCRIPTION
## Summary
- replace deprecated PingCAP download-domain references in Jenkins shared jobs
- update the public S3 bucket/path references to the new domain name

## Validation
- `git diff --check`
- verified no remaining old-domain matches in the touched files